### PR TITLE
mymysql doesn't support charset in URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Drivers marked with a `[*]` are tested with beedb
 
 Open a database link(may be will support ConnectionPool in the future)
 
-	db, err := sql.Open("mymysql", "test/xiemengjun/123456?charset=utf8")
+	db, err := sql.Open("mymysql", "test/xiemengjun/123456")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
In last commit default charset is utf8. If you need to modify it use godrv.Register function.
