### PR TITLE
Fix for issue 14, and probably issue 11 as well. 

### DIFF
--- a/beedb.go
+++ b/beedb.go
@@ -230,9 +230,8 @@ func (orm *Model) FindMap() (resultsSlice []map[string][]byte, err error) {
 		}
 		for ii, key := range fields {
 			rawValue := reflect.Indirect(reflect.ValueOf(scanResultContainers[ii]))
-			//if row is null then return nil
+			//if row is null then ignore
 			if rawValue.Interface() == nil {
-				result[key] = []byte("")
 				continue
 			}
 			aa := reflect.TypeOf(rawValue.Interface())


### PR DESCRIPTION
This fixes issue 14 - corruption of results when a row has any null entries. 

Changed FindMap to ignore columns with null values, rather than trying to set them to a blank string, which results in corruption of other columns, as presumably result[key] was invalid.

I think it's more desirable to leave null columns alone rather than setting them to blank anyway, as null is not considered the same as blank in sql. 
