### PR TITLE
Add option to pluralize table names

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ type Userinfo struct {
 ###***Caution***
 The structs Name 'UserInfo' will turn into the table name 'user_info', the same as the keyname.	
 If the keyname is 'UserName' will turn into the select colum 'user_name'	
+If you want table names to be pluralized so that 'UserInfo' struct was treated as 'user_infos' table, just set following option:
+```go
+beedb.PluralizeTableNames=true
+```
 	
 
 Create an object and save it

--- a/beedb.go
+++ b/beedb.go
@@ -11,6 +11,7 @@ import (
 )
 
 var OnDebug = false
+var PluralizeTableNames = false
 
 type Model struct {
 	Db              *sql.DB
@@ -143,7 +144,7 @@ func (orm *Model) Find(output interface{}) error {
 	var keys []string
 	results, _ := scanStructIntoMap(output)
 	if orm.TableName == "" {
-		orm.TableName = snakeCasedName(StructName(output))
+		orm.TableName = getTableName(StructName(output))
 	}
 	for key, _ := range results {
 		keys = append(keys, key)
@@ -177,7 +178,7 @@ func (orm *Model) FindAll(rowsSlicePtr interface{}) error {
 	var keys []string
 	results, _ := scanStructIntoMap(st.Interface())
 	if orm.TableName == "" {
-		orm.TableName = getTableName(rowsSlicePtr)
+		orm.TableName = getTableName(getTypeName(rowsSlicePtr))
 	}
 	for key, _ := range results {
 		keys = append(keys, key)
@@ -357,7 +358,7 @@ func (orm *Model) Save(output interface{}) error {
 	orm.ScanPK(output)
 	results, _ := scanStructIntoMap(output)
 	if orm.TableName == "" {
-		orm.TableName = snakeCasedName(StructName(output))
+		orm.TableName = getTableName(StructName(output))
 	}
 	id := results[snakeCasedName(orm.PrimaryKey)]
 	delete(results, snakeCasedName(orm.PrimaryKey))
@@ -515,7 +516,7 @@ func (orm *Model) Delete(output interface{}) (int64, error) {
 	orm.ScanPK(output)
 	results, _ := scanStructIntoMap(output)
 	if orm.TableName == "" {
-		orm.TableName = snakeCasedName(StructName(output))
+		orm.TableName = getTableName(StructName(output))
 	}
 	id := results[strings.ToLower(orm.PrimaryKey)]
 	condition := fmt.Sprintf("%v%v%v='%v'", orm.QuoteIdentifier, strings.ToLower(orm.PrimaryKey), orm.QuoteIdentifier, id)
@@ -544,7 +545,7 @@ func (orm *Model) DeleteAll(rowsSlicePtr interface{}) (int64, error) {
 	defer orm.InitModel()
 	orm.ScanPK(rowsSlicePtr)
 	if orm.TableName == "" {
-		orm.TableName = getTableName(rowsSlicePtr)
+		orm.TableName = getTableName(getTypeName(rowsSlicePtr))
 	}
 	var ids []string
 	val := reflect.Indirect(reflect.ValueOf(rowsSlicePtr))

--- a/util.go
+++ b/util.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"github.com/grsmv/inflect"
 )
 
 func getTypeName(obj interface{}) (typestr string) {
@@ -156,6 +157,9 @@ func StructName(s interface{}) string {
 	return v.Name()
 }
 
-func getTableName(obj interface{}) string {
-	return snakeCasedName(getTypeName(obj))
+func getTableName(name string) string {
+	if (PluralizeTableNames) {
+		return inflect.Pluralize(snakeCasedName(name))
+	}
+	return snakeCasedName(name)
 }


### PR DESCRIPTION
It was pretty uncomfortable for me to use beedb after rails as pluralizing table names feels more natural to me. Also problem I had was when I created User struct, I couldn't get users from "user" table (as user is a keyword). So here is my pull request with additional option to pluralize table names (if user wants).

``` go
beedb.PluralizeTableNames = true
```
