### PR TITLE
Made "go vet" compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Model a struct after a table in the db
 
 ```go
 type Userinfo struct {
-	Uid		int	`PK` //if the table's PrimaryKey is not id ,should add `PK` to ident
+	Uid		int	`beedb:"PK"` //if the table's PrimaryKey is not "Id", use this tag
 	Username	string
 	Departname	string
 	Created		time.Time

--- a/beedb.go
+++ b/beedb.go
@@ -100,16 +100,16 @@ func (orm *Model) ScanPK(output interface{}) *Model {
 		sliceValue := reflect.Indirect(reflect.ValueOf(output))
 		sliceElementType := sliceValue.Type().Elem()
 		for i := 0; i < sliceElementType.NumField(); i++ {
-			bb := reflect.ValueOf(sliceElementType.Field(i).Tag)
-			if bb.String() == "PK" {
+			bb := sliceElementType.Field(i).Tag
+			if bb.Get("beedb") == "PK" || reflect.ValueOf(bb).String() == "PK" {
 				orm.PrimaryKey = sliceElementType.Field(i).Name
 			}
 		}
 	} else {
 		tt := reflect.TypeOf(reflect.Indirect(reflect.ValueOf(output)).Interface())
 		for i := 0; i < tt.NumField(); i++ {
-			bb := reflect.ValueOf(tt.Field(i).Tag)
-			if bb.String() == "PK" {
+			bb := tt.Field(i).Tag
+			if bb.Get("beedb") == "PK" || reflect.ValueOf(bb).String() == "PK" {
 				orm.PrimaryKey = tt.Field(i).Name
 			}
 		}

--- a/example/gomysql.go
+++ b/example/gomysql.go
@@ -28,7 +28,7 @@ CREATE TABLE `userdeatail` (
 var orm beedb.Model
 
 type Userinfo struct {
-	Uid        int `PK`
+	Uid        int `beedb:"PK"`
 	Username   string
 	Departname string
 	Created    time.Time

--- a/example/mssql.go
+++ b/example/mssql.go
@@ -26,7 +26,7 @@ CREATE TABLE userdeatail (
 var orm beedb.Model
 
 type Userinfo struct {
-	Uid        int `PK`
+	Uid        int `beedb:"PK"`
 	Username   string
 	Departname string
 	Created    string

--- a/example/mysql.go
+++ b/example/mysql.go
@@ -28,7 +28,7 @@ CREATE TABLE `userdeatail` (
 var orm beedb.Model
 
 type Userinfo struct {
-	Uid        int `PK`
+	Uid        int `beedb:"PK"`
 	Username   string
 	Departname string
 	Created    time.Time

--- a/example/pg.go
+++ b/example/pg.go
@@ -31,7 +31,7 @@ WITH(OIDS=FALSE);
 var orm beedb.Model
 
 type Userinfo struct {
-	Uid        int `PK`
+	Uid        int `beedb:"PK"`
 	Username   string
 	Departname string
 	Created    string

--- a/example/sqlite.go
+++ b/example/sqlite.go
@@ -26,7 +26,7 @@ CREATE TABLE `userdeatail` (
 var orm beedb.Model
 
 type Userinfo struct {
-	Uid        int `PK`
+	Uid        int `beedb:"PK"`
 	Username   string
 	Departname string
 	Created    string


### PR DESCRIPTION
Adjusted the primary key tag from `PK` to `beedb:"PK"` to be compatible with current best practices.  The old method of tagging still works, so old code will continue to function without changes.
