### PR TITLE
beedb.go: use limit/offset syntax when constructing sql

### DIFF
--- a/beedb.go
+++ b/beedb.go
@@ -349,7 +349,7 @@ func (orm *Model) generateSql() (a string) {
 			a = fmt.Sprintf("%v ORDER BY %v", a, orm.OrderStr)
 		}
 		if orm.OffsetStr > 0 {
-			a = fmt.Sprintf("%v LIMIT %v, %v", a, orm.OffsetStr, orm.LimitStr)
+			a = fmt.Sprintf("%v LIMIT %v OFFSET %v", a, orm.LimitStr, orm.OffsetStr)
 		} else if orm.LimitStr > 0 {
 			a = fmt.Sprintf("%v LIMIT %v", a, orm.LimitStr)
 		}


### PR DESCRIPTION
Traditionally in database management systems, one uses "LIMIT #,#" to slice rows on a select statement. Many database management systems also support a synonomous API using "LIMIT # OFFSET #" to achieve the same thing. Some database management systems have decided to disable the former method of slicing rows. For example, PostgreSQL disabled support for "LIMIT #,#" in version 7.3 ([release notes](http://www.postgresql.org/docs/devel/static/release-7-3.html)). Versions below 8.3 for PostgreSQL are so old that they are now unsupported. This means that at the moment, `beedb` does not support slicing rows for any recent version of PostgreSQL.

This change updates `beedb.go` to use the "LIMIT # OFFSET #" query API. The change restores slicing functionality for more recent versions of PostgreSQL while hopefully not breaking any functionality for any other database management systems. As far as I know, they all support this syntax. I know for certain that this change works with PostgresSQL but I haven't tested it with any other database management system.
