### PR TITLE
Allow specifying columns with Select() even when using FindAll()

### DIFF
--- a/beedb.go
+++ b/beedb.go
@@ -191,11 +191,13 @@ func (orm *Model) FindAll(rowsSlicePtr interface{}) error {
 	if orm.TableName == "" {
 		orm.TableName = getTableName(getTypeName(rowsSlicePtr))
 	}
-	for key, _ := range results {
-		keys = append(keys, key)
+	// If we've already specific columns with Select(), use that
+	if orm.ColumnStr == "*" {
+		for key, _ := range results {
+			keys = append(keys, key)
+		}
+		orm.ColumnStr = strings.Join(keys, ", ")
 	}
-	orm.ColumnStr = strings.Join(keys, ", ")
-
 	resultsSlice, err := orm.FindMap()
 	if err != nil {
 		return err


### PR DESCRIPTION
Normally, calling FindAll() will select all columns in the table. This patch allows the user to specify which columns to select.
