### PR TITLE
Make beedb map structs to tables/columns by tags instead of putting underlines before capital letters

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,20 +63,16 @@ Model a struct after a table in the db
 
 ```go
 type Userinfo struct {
-	Uid		int	`beedb:"PK"` //if the table's PrimaryKey is not "Id", use this tag
-	Username	string
-	Departname	string
-	Created		time.Time
+	Uid		int	`beedb:"PK" slq:"UID" tname:"USER_INFO"` //if the table's PrimaryKey is not "Id", use this tag
+	Username	string `slq:"USERNAME"`
+	Departname	string `slq:"DEPARTNAME"`
+	Created		time.Time `slq:"CREATED"`
 }
 ```
 
 ###***Caution***
-The structs Name 'UserInfo' will turn into the table name 'user_info', the same as the keyname.	
-If the keyname is 'UserName' will turn into the select colum 'user_name'	
-If you want table names to be pluralized so that 'UserInfo' struct was treated as 'user_infos' table, just set following option:
-```go
-beedb.PluralizeTableNames=true
-```
+The structs Name 'UserInfo' will turn into the table name 'USER_INFO', as defined by the **tname** tag.	
+If the key 'UserName' will turn into the select colum 'USERNAME' because of the **sql** tag.
 	
 
 Create an object and save it

--- a/beedb.go
+++ b/beedb.go
@@ -387,10 +387,9 @@ func (orm *Model) Save(output interface{}) error {
 
 	if orm.TableName == "" {
 		orm.TableName = getTableName(output)
-		fmt.Println("TABLE NAME IS: " + orm.TableName)
 	}
-	id := results[snakeCasedName(orm.PrimaryKey)]
-	delete(results, snakeCasedName(orm.PrimaryKey))
+	id := results[orm.PrimaryKey]
+	delete(results, orm.PrimaryKey)
 	if reflect.ValueOf(id).Int() == 0 {
 		structPtr := reflect.ValueOf(output)
 		structVal := structPtr.Elem()

--- a/beedb.go
+++ b/beedb.go
@@ -32,7 +32,7 @@ type Model struct {
 }
 
 /**
- * Add New sql.DB in the future i will add ConnectionPool.Get() 
+ * Add New sql.DB in the future i will add ConnectionPool.Get()
  */
 func New(db *sql.DB, options ...interface{}) (m Model) {
 	if len(options) == 0 {
@@ -148,7 +148,7 @@ func (orm *Model) Find(output interface{}) error {
 	}
 
 	if orm.TableName == "" {
-		orm.TableName = getTableName(StructName(output))
+		orm.TableName = getTableName(output)
 	}
 	// If we've already specific columns with Select(), use that
 	if orm.ColumnStr == "*" {
@@ -275,15 +275,15 @@ func (orm *Model) FindMap() (resultsSlice []map[string][]byte, err error) {
 			case reflect.String:
 				str = vv.String()
 				result[key] = []byte(str)
-			//时间类型	
+			//时间类型
 			case reflect.Struct:
 				str = rawValue.Interface().(time.Time).Format("2006-01-02 15:04:05.000 -0700")
 				result[key] = []byte(str)
 			case reflect.Bool:
-				if (vv.Bool()) {
-				  result[key] = []byte("1")
+				if vv.Bool() {
+					result[key] = []byte("1")
 				} else {
-				  result[key] = []byte("0")
+					result[key] = []byte("0")
 				}
 			}
 		}
@@ -386,7 +386,8 @@ func (orm *Model) Save(output interface{}) error {
 	}
 
 	if orm.TableName == "" {
-		orm.TableName = getTableName(StructName(output))
+		orm.TableName = getTableName(output)
+		fmt.Println("TABLE NAME IS: " + orm.TableName)
 	}
 	id := results[snakeCasedName(orm.PrimaryKey)]
 	delete(results, snakeCasedName(orm.PrimaryKey))
@@ -552,7 +553,7 @@ func (orm *Model) Delete(output interface{}) (int64, error) {
 	}
 
 	if orm.TableName == "" {
-		orm.TableName = getTableName(StructName(output))
+		orm.TableName = getTableName(output)
 	}
 	id := results[strings.ToLower(orm.PrimaryKey)]
 	condition := fmt.Sprintf("%v%v%v='%v'", orm.QuoteIdentifier, strings.ToLower(orm.PrimaryKey), orm.QuoteIdentifier, id)
@@ -581,6 +582,7 @@ func (orm *Model) DeleteAll(rowsSlicePtr interface{}) (int64, error) {
 	defer orm.InitModel()
 	orm.ScanPK(rowsSlicePtr)
 	if orm.TableName == "" {
+		//TODO: fix table name
 		orm.TableName = getTableName(getTypeName(rowsSlicePtr))
 	}
 	var ids []string

--- a/util.go
+++ b/util.go
@@ -2,8 +2,6 @@ package beedb
 
 import (
 	"errors"
-	"fmt"
-	"github.com/grsmv/inflect"
 	"reflect"
 	"strconv"
 	"strings"
@@ -190,9 +188,6 @@ func getTableName(s interface{}) string {
 	v := reflect.TypeOf(s)
 	if v.Kind() == reflect.String {
 		s2, _ := s.(string)
-		if PluralizeTableNames {
-			return inflect.Pluralize(snakeCasedName(s2))
-		}
 		return snakeCasedName(s2)
 	}
 	tn := scanTableName(s)
@@ -208,7 +203,6 @@ func scanTableName(s interface{}) string {
 		sliceElementType := sliceValue.Type().Elem()
 		for i := 0; i < sliceElementType.NumField(); i++ {
 			bb := sliceElementType.Field(i).Tag
-			fmt.Println("TNAME: " + bb.Get("tname"))
 			if len(bb.Get("tname")) > 0 {
 				return bb.Get("tname")
 			}
@@ -217,7 +211,6 @@ func scanTableName(s interface{}) string {
 		tt := reflect.TypeOf(reflect.Indirect(reflect.ValueOf(s)).Interface())
 		for i := 0; i < tt.NumField(); i++ {
 			bb := tt.Field(i).Tag
-			fmt.Println("TNAME: " + bb.Get("tname"))
 			if len(bb.Get("tname")) > 0 {
 				return bb.Get("tname")
 			}
@@ -226,10 +219,3 @@ func scanTableName(s interface{}) string {
 	return ""
 
 }
-
-/*func getTableName(name string) string {
-	if PluralizeTableNames {
-		return inflect.Pluralize(snakeCasedName(name))
-	}
-	return snakeCasedName(name)
-}*/


### PR DESCRIPTION
Since it's not always that you're working with a fresh database to have liberty on using the most comfortable naming convention for tables and columns, I made beedb recognise "sql" tags to map them any way you need (like **_mgo**_ does with _bson_ tags):

```
type Car struct {
    Id         int      `beedb:"PK" sql:"ID" tname:"CARS"`
    Name       string   `sql:"car_name"`
    Type       string   `sql:"car_type"`
}
```

The tag _tname_ is there if you need to specify the table name as well. There could be a better way for this (sadly the struct itself can't have a tag) so I'm open for suggestions.
