### PR TITLE
Added Model nesting by using the 'inline' keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,23 @@ Group By And Having
 a, _ := orm.SetTable("userinfo").GroupBy("username").Having("username='astaxie'").FindMap()
 ```
 
+Nesting Models (inline)
+
+```go
+type SQLModel struct {
+	Id       int       `beedb:"PK" sql:"id"`
+	Created  time.Time `sql:"created"`
+	Modified time.Time `sql:"modified"`
+}
+type User struct {
+	SQLModel `sql:",inline"`
+	Name     string `sql:"name" tname:"fn_group"`
+	Auth     int    `sql:"auth"`
+}
+// the SQL table has the columns: id, name, auth, created, modified
+// They are marshalled and unmarshalled automatically because of the inline keyword
+```
+
 ## LICENSE
 
  BSD License

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,39 @@
+package beedb
+
+import (
+	"testing"
+	"time"
+)
+
+type User struct {
+	SQLModel `sql:",inline"`
+	Name     string `sql:"name" tname:"fn_group"`
+	Auth     int    `sql:"auth"`
+}
+
+type SQLModel struct {
+	Id       int       `beedb:"PK" sql:"id"`
+	Created  time.Time `sql:"created"`
+	Modified time.Time `sql:"modified"`
+}
+
+func TestMapToStruct(t *testing.T) {
+	target := &User{}
+	input := map[string][]byte{
+		"name":     []byte("Test User"),
+		"auth":     []byte("1"),
+		"id":       []byte("1"),
+		"created":  []byte("2014-01-01 10:10:10"),
+		"modified": []byte("2014-01-01 10:10:10"),
+	}
+	err := scanMapIntoStruct(target, input)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	_, err = scanStructIntoMap(target)
+
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+}


### PR DESCRIPTION
Here's another feature inspired from [mgo](http://labix.org/mgo). It allows beedb's reflection to marshall/unmarshall the nested structs as if its fields were at the same level as the main struct's fields.

``` go
//example
var orm beedb.Model

type SQLModel struct {
    Id       int       `beedb:"PK" sql:"id"`
    Created  time.Time `sql:"created"`
    Modified time.Time `sql:"modified"`
}
type User struct {
    SQLModel `sql:",inline"`
    Name     string `sql:"name" tname:"fn_group"`
    Auth     int    `sql:"auth"`
}

func main() {
    // ...
    user := &User{}
    // ...
    orm.Where("id=?", 1).Find(user)
    fmt.Println(user.Id)
    fmt.Println(user.Created)
    fmt.Println(user.Name)
}
```
